### PR TITLE
fix "UTF_7 is not a class" and similar errors 

### DIFF
--- a/lib/shoes.rb
+++ b/lib/shoes.rb
@@ -8,7 +8,7 @@ ARGV.delete_if { |x| x =~ /-psn_/ }
 
 class Encoding
   %w[UTF_7 UTF_16BE UTF_16LE UTF_32BE UTF_32LE].each do |enc|
-    eval "class #{enc};end"
+    eval "class #{enc};end" unless const_defined? enc.to_sym
   end
 end
 


### PR DESCRIPTION
problem reported with ruby1.9.2p0 on Debian Squeeze (my system)

and also here:
https://github.com/shoes/shoes/issues/105
http://librelist.com/browser//shoes/2011/5/24/building-shoes-for-32-bit-osx/
