### PR TITLE
Untested, but if you run `builddeps.sh --download` you won't have to down

### DIFF
--- a/builddeps.sh
+++ b/builddeps.sh
@@ -3,6 +3,24 @@
 rm -rf /tmp/dep
 cd /usr/local/src/
 
+#curl dependencies if asked
+if [ "$1" = "--download" ]; then
+	curl -O http://pkg-config.freedesktop.org/releases/pkg-config-0.20.tar.gz
+	curl -O http://downloads.sourceforge.net/project/libpng/libpng14/older-releases/1.4.1/libpng-1.4.1.tar.gz?r=&ts=1312207981&use_mirror=voxel
+	curl -O http://downloads.sourceforge.net/project/giflib/giflib%204.x/giflib-4.1.6/giflib-4.1.6.tar.gz?r=&ts=1312208000&use_mirror=softlayer
+	curl -O http://ftp.gnu.org/gnu/gettext/gettext-0.17.tar.gz
+	curl -O http://ftp.gnu.org/gnu/libiconv/libiconv-1.13.tar.gz
+	curl -O http://cgit.freedesktop.org/pixman/snapshot/pixman-0.18.0.tar.gz
+	curl -O http://ftp.gnome.org/pub/GNOME/sources/pango/1.28/pango-1.28.0.tar.gz
+	curl -O http://portaudio.com/archives/pa_stable_v19_20071207.tar.gz
+	curl -O http://cairographics.org/releases/cairo-1.8.10.tar.gz
+	curl -O http://ijg.org/files/jpegsrc.v8a.tar.gz
+	curl -O http://ftp.gnome.org/pub/gnome/sources/glib/2.24/glib-2.24.0.tar.gz
+	curl -O http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz
+	curl -O http://production.cf.rubygems.org/rubygems/rubygems-1.3.6.tgz
+
+	for file in ls *.tar.gz *.tgz; do tar -xzf $file; done
+fi
 #make clean all deps
 cd pkg-config-0.20
 make clean


### PR DESCRIPTION
Untested, but if you run `builddeps.sh --download` you won't have to download the dependencies first.
