### PR TITLE
Remove some compile warnings

### DIFF
--- a/make/darwin/env.rb
+++ b/make/darwin/env.rb
@@ -14,7 +14,9 @@ end
 ADD_DLL = []
 
 # Linux build environment
-if `which pkg-config` != ""
+pkg_config = `which pkg-config` != ""
+pkgs = `pkg-config --list-all`.split("\n").map {|p| p.split.first} unless not pkg_config
+if pkg_config and pkgs.include?("cairo") and pkgs.include?("pango")
   CAIRO_CFLAGS = ENV['CAIRO_CFLAGS'] || `pkg-config --cflags cairo`.strip
   CAIRO_LIB = ENV['CAIRO_LIB'] ? "-L#{ENV['CAIRO_LIB']}" : `pkg-config --libs cairo`.strip
   PANGO_CFLAGS = ENV['PANGO_CFLAGS'] || `pkg-config --cflags pango`.strip

--- a/shoes/native/cocoa.m
+++ b/shoes/native/cocoa.m
@@ -116,11 +116,11 @@
   Data_Get_Struct(app, shoes_app, a);
   Data_Get_Struct(a->canvas, shoes_canvas, canvas);
   if (type == s_motion)
-    shoes_app_motion(a, p.x, (canvas->height - p.y) + canvas->slot->scrolly);
+    shoes_app_motion(a, (int)round(p.x), (canvas->height - (int)round(p.y)) + canvas->slot->scrolly);
   else if (type == s_click)
-    shoes_app_click(a, b, p.x, (canvas->height - p.y) + canvas->slot->scrolly);
+    shoes_app_click(a, b, (int)round(p.x), (canvas->height - (int)round(p.y)) + canvas->slot->scrolly);
   else if (type == s_release)
-    shoes_app_release(a, b, p.x, (canvas->height - p.y) + canvas->slot->scrolly);
+    shoes_app_release(a, b, (int)round(p.x), (canvas->height - (int)round(p.y)) + canvas->slot->scrolly);
 }
 - (void)mouseDown: (NSEvent *)e
 {

--- a/shoes/native/cocoa.m
+++ b/shoes/native/cocoa.m
@@ -116,11 +116,11 @@
   Data_Get_Struct(app, shoes_app, a);
   Data_Get_Struct(a->canvas, shoes_canvas, canvas);
   if (type == s_motion)
-    shoes_app_motion(a, (int)round(p.x), (canvas->height - (int)round(p.y)) + canvas->slot->scrolly);
+    shoes_app_motion(a, INT(p.x), (canvas->height - INT(p.y)) + canvas->slot->scrolly);
   else if (type == s_click)
-    shoes_app_click(a, b, (int)round(p.x), (canvas->height - (int)round(p.y)) + canvas->slot->scrolly);
+    shoes_app_click(a, b, INT(p.x), (canvas->height - INT(p.y)) + canvas->slot->scrolly);
   else if (type == s_release)
-    shoes_app_release(a, b, (int)round(p.x), (canvas->height - (int)round(p.y)) + canvas->slot->scrolly);
+    shoes_app_release(a, b, INT(p.x), (canvas->height - INT(p.y)) + canvas->slot->scrolly);
 }
 - (void)mouseDown: (NSEvent *)e
 {

--- a/shoes/world.h
+++ b/shoes/world.h
@@ -37,6 +37,8 @@ extern SHOES_EXTERN shoes_world_t *shoes_world;
   if (RARRAY_LEN(shoes_world->apps) > 0) \
     Data_Get_Struct(rb_ary_entry(shoes_world->apps, 0), shoes_app, appvar)
 
+#define INT(x) ((int)round(x))
+
 //
 // Shoes World
 // 


### PR DESCRIPTION
- cast some doubles to the ints that shoes code expects, using a macro
- remove the warning that pango is not installed (occurs during `rake build` when pkg-config is installed, but pango is not), and similarly for cairo
