### PR TITLE
fix tabbing between fields on osx

### DIFF
--- a/shoes/native/cocoa.m
+++ b/shoes/native/cocoa.m
@@ -103,6 +103,7 @@
   [self center];
   [self makeKeyAndOrderFront: self];
   [self setAcceptsMouseMovedEvents: YES];
+  [self setAutorecalculatesKeyViewLoop: YES];
   [self setDelegate: self];
 }
 - (void)disconnectApp


### PR DESCRIPTION
add `setAutorecalculatesKeyViewLoop` on our main `NSWindow`; fixes #65

this looks from my research like it shouldn't have any adverse side effects; it fixes the test case and didn't seem to completely explode HH when i opened it up and clicked around.

that being said, i'm new to shoes and also objective-c, so merger beware.  this is most definitely a cargo cult-ish fix from a rubyist.  looking forward to learning more about shoes/obj-c so i can push out some more confident patches than this. :)
