### PR TITLE
Changes based on issue https://github.com/shoes/shoes/issues/164 to use ...

### DIFF
--- a/lib/shoes.rb
+++ b/lib/shoes.rb
@@ -533,15 +533,15 @@ class Shoes
   end
 
   class Types::Widget
-    @types = {}
+    @@types = {}
     def self.inherited subc
       methc = subc.to_s[/(^|::)(\w+)$/, 2].
               gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
               gsub(/([a-z\d])([A-Z])/,'\1_\2').downcase
-      @types[methc] = subc
+      @@types[methc] = subc
       Shoes.class_eval %{
         def #{methc}(*a, &b)
-          a.unshift Widget.instance_variable_get("@types")[#{methc.dump}]
+          a.unshift Widget.class_variable_get("@@types")[#{methc.dump}]
           widget(*a, &b)
         end
       }


### PR DESCRIPTION
...class variable vs. class instance variable for implementing Registry pattern of derived widget classes.  This change is required to ensure that you can have multiple levels of inheritance from Widget.  Without this change, you get the error highlighted in the issue above.
