### PR TITLE
Upgrade shoes .rvmrc to ruby 1.9.3[-p0]

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm 1.9.2@shoes
+rvm --create 1.9.3@shoes


### PR DESCRIPTION
I tested again now with a new "shoes" gemset and all works correctly now with 1.9.3-p0.

I initially had a problem, discussed here

http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/391831
http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/391850

but that turned out to be not related to version 1.9.3-p0 but to my
local set-up.

``` bash

peterv@ASUS:~/b/github/petervandenabeele$ rvm gemset delete shoes
WARN: Are you SURE you wish to remove the entire gemset directory 'shoes' (/home/peterv/.rvm/gems/ruby-1.9.2-p290@shoes)?
(anything other than 'yes' will cancel) > yes
peterv@ASUS:~/b/github/petervandenabeele$ cd shoes/
peterv@ASUS:~/b/github/petervandenabeele/shoes$ rvm current
ruby-1.9.3-p0@shoes
peterv@ASUS:~/b/github/petervandenabeele/shoes$ bundle install
Fetching source index for http://rubygems.org/
Installing rake (0.9.2) 
Installing builder (3.0.0) 
Installing diff-lcs (1.1.3) 
Installing json (1.6.1) with native extensions 
Installing gherkin (2.5.1) with native extensions 
Installing term-ansicolor (1.0.6) 
Installing cucumber (1.1.0) 
Installing net-http-digest_auth (1.1.1) 
Installing net-http-persistent (1.9) 
Installing nokogiri (1.5.0) with native extensions 
Installing webrobots (0.0.11) 
Installing mechanize (2.0.1) 
Installing rspec-core (2.6.4) 
Installing rspec-expectations (2.6.0) 
Installing rspec-mocks (2.6.0) 
Installing rspec (2.6.0) 
Installing shoes-mocks (0.0.2) 
Installing shoes-cucumber (0.0.2) 
Using bundler (1.0.21) 
Your bundle is complete! Use `bundle show [gemname]` to see where a bundled gem is installed.
peterv@ASUS:~/b/github/petervandenabeele/shoes$ ruby -v
ruby 1.9.3p0 (2011-10-30 revision 33570) [i686-linux]
peterv@ASUS:~/b/github/petervandenabeele/shoes$ cucumber
...
10 scenarios (10 passed)
33 steps (33 passed)
0m0.046s
peterv@ASUS:~/b/github/petervandenabeele/shoes$
```
