### PR TITLE
fixed the equality for the spaceship operator

### DIFF
--- a/shoes/ruby.c
+++ b/shoes/ruby.c
@@ -48,7 +48,7 @@ ts_funcall2(VALUE obj, ID meth, int argc, VALUE *argv)
   if (!rb_block_given_p())
     return rb_funcall2(obj, meth, argc, argv);
   tmp[0] = obj;
-  tmp[1] = (VALUE)meth; 
+  tmp[1] = (VALUE)meth;
   tmp[2] = (VALUE)argc;
   tmp[3] = (VALUE)argv;
   return rb_iterate((VALUE(*)(VALUE))ts_each, (VALUE)tmp, CASTHOOK(rb_yield), 0);
@@ -107,9 +107,9 @@ rb_parse_args_p(unsigned char rais, int argc, const VALUE *argv, const char *fmt
     {
       if (!x) m = i;
     }
-    else if (*p == 's') 
+    else if (*p == 's')
       CHECK_ARG_COERCE(T_STRING, to_str)
-    else if (*p == 'S') 
+    else if (*p == 'S')
       CHECK_ARG_COERCE(T_STRING, to_s)
     else if (*p == 'i')
       CHECK_ARG_COERCE(T_FIXNUM, to_int)
@@ -182,7 +182,7 @@ long
 rb_ary_index_of(VALUE ary, VALUE val)
 {
   long i;
- 
+
   for (i=0; i<RARRAY_LEN(ary); i++) {
     if (rb_equal(RARRAY_PTR(ary)[i], val))
       return i;
@@ -200,7 +200,7 @@ rb_ary_insert_at(VALUE ary, long index, int len, VALUE ary2)
 
 //
 // from ruby's eval.c
-// 
+//
 static inline VALUE
 call_cfunc(HOOK func, VALUE recv, int len, int argc, VALUE *argv)
 {
@@ -304,7 +304,7 @@ shoes_safe_block(VALUE self, VALUE block, VALUE args)
   sb.args = args;
   rb_gc_register_address(&args);
 
-  v = rb_rescue2(CASTHOOK(shoes_safe_block_call), (VALUE)&sb, 
+  v = rb_rescue2(CASTHOOK(shoes_safe_block_call), (VALUE)&sb,
     CASTHOOK(shoes_safe_block_exception), (VALUE)&sb, rb_cObject, 0);
   rb_gc_unregister_address(&args);
   return v;
@@ -320,7 +320,7 @@ shoes_px(VALUE obj, int dv, int pv, int nv)
     obj = rb_funcall(obj, s_to_i, 0);
     if (len > 1 && ptr[len - 1] == '%')
     {
-      obj = rb_funcall(obj, s_mult, 1, rb_float_new(0.01)); 
+      obj = rb_funcall(obj, s_mult, 1, rb_float_new(0.01));
     }
   }
   if (rb_obj_is_kind_of(obj, rb_cFloat)) {
@@ -430,7 +430,7 @@ shoes_place_exact(shoes_place *place, VALUE attr, int ox, int oy)
   x = ATTR(attr, bottom);
   if (!NIL_P(x)) place->ih = place->h = (NUM2INT(x) + oy) - place->y;
 
-  if (RTEST(ATTR(attr, center))) 
+  if (RTEST(ATTR(attr, center)))
   {
     place->ix = place->x = place->x - (place->w / 2);
     place->iy = place->y = place->y - (place->h / 2);
@@ -544,10 +544,10 @@ shoes_place_decide(shoes_place *place, VALUE c, VALUE attr, int dw, int dh, unsi
       ORIGIN(canvas->place) ? canvas->height : canvas->fully) + oy;
     if (!ORIGIN(canvas->place))
     {
-      place->dx = canvas->place.dx; 
+      place->dx = canvas->place.dx;
       place->dy = canvas->place.dy;
     }
-    place->dx += PXN(attr, displace_left, 0, CPW(canvas)); 
+    place->dx += PXN(attr, displace_left, 0, CPW(canvas));
     place->dy += PXN(attr, displace_top, 0, CPH(canvas));
 
     place->flags |= NIL_P(ATTR(attr, left)) && NIL_P(ATTR(attr, right)) ? 0 : FLAG_ABSX;
@@ -839,7 +839,7 @@ shoes_shape_check(cairo_t *cr, shoes_place *place)
   if (place->iw < 0) ox1 = place->ix - (ox2 = -place->iw);
   if (place->ih < 0) oy1 = place->iy - (oy2 = -place->ih);
   if (cy2 - cy1 == 1.0 && cx2 - cx1 == 1.0) return 1;
-  if ((ox1 < cx1 && ox2 < cx1) || (oy1 < cy1 && oy2 < cy1) || 
+  if ((ox1 < cx1 && ox2 < cx1) || (oy1 < cy1 && oy2 < cy1) ||
       (ox1 > cx2 && ox2 > cx2) || (oy1 > cy2 && oy2 > cy2)) return 0;
   return 1;
 }
@@ -1001,7 +1001,7 @@ shoes_shape_draw(VALUE self, VALUE c, VALUE actual)
   shoes_place_exact(&place, self_t->attr, CPX(canvas), CPY(canvas));
 
   if (RTEST(actual))
-    shoes_shape_sketch(CCR(canvas), self_t->name, &place, self_t->st, self_t->attr, self_t->line, 1); 
+    shoes_shape_sketch(CCR(canvas), self_t->name, &place, self_t->st, self_t->attr, self_t->line, 1);
 
   self_t->place = place;
   return self;
@@ -1026,7 +1026,7 @@ shoes_shape_motion(VALUE self, int x, int y, char *touch)
     //   cairo_append_path(cr, self_t->line);
     // }
     // else
-      shoes_shape_sketch(cr, self_t->name, &self_t->place, self_t->st, self_t->attr, self_t->line, 0); 
+      shoes_shape_sketch(cr, self_t->name, &self_t->place, self_t->st, self_t->attr, self_t->line, 0);
     in_shape = cairo_in_fill(cr, x, y);
     cairo_destroy(cr);
 
@@ -1854,11 +1854,16 @@ shoes_color_spaceship(VALUE self, VALUE c2)
   GET_STRUCT(color, color);
   if (!rb_obj_is_kind_of(c2, cColor)) return Qnil;
   Data_Get_Struct(c2, shoes_color, color2);
-  v1 = color->r + color->g + color->b;
-  v2 = color2->r + color2->g + color2->b;
-  if (v1 == v2) return INT2FIX(0);
-  if (v1 > v2)  return INT2FIX(1);
-  else          return INT2FIX(-1);
+  if ((color->r == color2->r) && (color->g == color2->g) && (color->b == color2->b))
+  {
+    return INT2FIX(0);
+  } else
+  {
+    v1 = color->r + color->g + color->b;
+    v2 = color2->r + color2->g + color2->b;
+    if (v1 > v2)  return INT2FIX(1);
+    else          return INT2FIX(-1);
+  }
 }
 
 VALUE
@@ -1945,8 +1950,8 @@ shoes_color_to_s(VALUE self)
 {
   GET_STRUCT(color, color);
 
-  VALUE ary = rb_ary_new3(4, 
-    INT2NUM(color->r), INT2NUM(color->g), INT2NUM(color->b), 
+  VALUE ary = rb_ary_new3(4,
+    INT2NUM(color->r), INT2NUM(color->g), INT2NUM(color->b),
     rb_float_new((color->a * 1.) / 255.));
 
   if (color->a == 255)
@@ -1972,7 +1977,7 @@ shoes_color_method_missing(int argc, VALUE *argv, VALUE self)
   if (NIL_P(c))
   {
     self = rb_inspect(self);
-    rb_raise(rb_eNoMethodError, "undefined method `%s' for %s", 
+    rb_raise(rb_eNoMethodError, "undefined method `%s' for %s",
       rb_id2name(SYM2ID(cname)), RSTRING_PTR(self));
   }
 
@@ -2671,7 +2676,7 @@ shoes_textblock_iter_pango(VALUE texts, shoes_textblock *block, shoes_app *app)
       {
         start = RSTRING_PTR(v);
         if (!g_utf8_validate(start, RSTRING_LEN(v), (const gchar **)&end))
-          shoes_error("not a valid UTF-8 string: %.*s", end - start, start); 
+          shoes_error("not a valid UTF-8 string: %.*s", end - start, start);
         if (end > start)
           g_string_append_len(block->text, start, end - start);
       }
@@ -2712,7 +2717,7 @@ shoes_textblock_on_layout(shoes_app *app, VALUE klass, shoes_textblock *block)
   VALUE str = Qnil, hsh = Qnil, oattr = Qnil;
   g_return_if_fail(block != NULL);
   g_return_if_fail(PANGO_IS_LAYOUT(block->layout));
-  
+
   oattr = block->attr;
   hsh = rb_hash_aref(app->styles, klass);
 
@@ -2776,7 +2781,7 @@ shoes_textblock_draw(VALUE self, VALUE c, VALUE actual)
   self_t->place.y = ATTR2(int, self_t->attr, top, canvas->cy);
   if (!ORIGIN(canvas->place))
   {
-    self_t->place.dx = canvas->place.dx; 
+    self_t->place.dx = canvas->place.dx;
     self_t->place.dy = canvas->place.dy;
   }
   else
@@ -2784,7 +2789,7 @@ shoes_textblock_draw(VALUE self, VALUE c, VALUE actual)
     self_t->place.dx = 0;
     self_t->place.dy = 0;
   }
-  self_t->place.dx += PXN(self_t->attr, displace_left, 0, CPW(canvas)); 
+  self_t->place.dx += PXN(self_t->attr, displace_left, 0, CPW(canvas));
   self_t->place.dy += PXN(self_t->attr, displace_top, 0, CPH(canvas));
   self_t->place.w = ATTR2(int, self_t->attr, width, canvas->place.iw - (canvas->cx - self_t->place.x));
   self_t->place.iw = self_t->place.w - (lmargin + rmargin);
@@ -2811,7 +2816,7 @@ shoes_textblock_draw(VALUE self, VALUE c, VALUE actual)
       }
     }
   }
-  
+
   pango_layout_set_width(self_t->layout, self_t->place.iw * PANGO_SCALE);
   pango_layout_set_spacing(self_t->layout, ld * PANGO_SCALE);
   shoes_textblock_on_layout(canvas->app, rb_obj_class(self), self_t);
@@ -2913,7 +2918,7 @@ shoes_textblock_draw(VALUE self, VALUE c, VALUE actual)
     if (NIL_P(ATTR(self_t->attr, margin)) && NIL_P(ATTR(self_t->attr, margin_top)))
       bmargin = lrect.height;
 
-    INFO("CX: (%d, %d) / LRECT: (%d, %d) / END: (%d, %d)\n", 
+    INFO("CX: (%d, %d) / LRECT: (%d, %d) / END: (%d, %d)\n",
       canvas->cx, canvas->cy,
       lrect.x, lrect.width,
       canvas->endx, canvas->endy);
@@ -3903,15 +3908,15 @@ shoes_msg(ID typ, VALUE str)
 {
 #ifdef RUBY_1_9
   ID func = rb_frame_this_func();
-  rb_ary_push(shoes_world->msgs, rb_ary_new3(6, 
+  rb_ary_push(shoes_world->msgs, rb_ary_new3(6,
     ID2SYM(typ), str, rb_funcall(rb_cTime, s_now, 0),
-    func ? ID2SYM(func) : Qnil, 
+    func ? ID2SYM(func) : Qnil,
     rb_str_new2("<unknown>"), INT2NUM(0)));
 #else
   ID func = rb_frame_last_func();
-  rb_ary_push(shoes_world->msgs, rb_ary_new3(6, 
+  rb_ary_push(shoes_world->msgs, rb_ary_new3(6,
     ID2SYM(typ), str, rb_funcall(rb_cTime, s_now, 0),
-    func ? ID2SYM(func) : Qnil, 
+    func ? ID2SYM(func) : Qnil,
     rb_str_new2(ruby_sourcefile), INT2NUM(ruby_sourceline)));
 #endif
 }
@@ -4082,7 +4087,7 @@ shoes_http_threaded(VALUE self, VALUE url, VALUE attr)
     url_string = strdup(RSTRING_PTR(url));
     url = rb_funcall(rb_mKernel, s_URI, 1, url);
   }
-  
+
   VALUE scheme = rb_funcall(url, s_scheme, 0);
   VALUE host = rb_funcall(url, s_host, 0);
   VALUE port = rb_funcall(url, s_port, 0);
@@ -4094,7 +4099,7 @@ shoes_http_threaded(VALUE self, VALUE url, VALUE attr)
     if (RSTRING_PTR(path)[0] == '/') slash[0] = '\0';
     sprintf(url_string, "%s://%s:%d%s%s", scheme, host, port, slash, path);
   }
-  
+
   shoes_http_request *req = SHOE_ALLOC(shoes_http_request);
   SHOE_MEMZERO(req, shoes_http_request, 1);
   req->url = url_string;
@@ -4923,3 +4928,4 @@ shoes_ruby_init()
   rb_define_method(rb_mKernel, "ask_save_folder", CASTHOOK(shoes_dialog_save_folder), -1);
   rb_define_method(rb_mKernel, "font", CASTHOOK(shoes_font), 1);
 }
+


### PR DESCRIPTION
This shall fix #175 .

About the many loc changed, I really only changed 1857 till 1866 - the others were changed by my editor (automatically removing trailing whitespaces) - if this is a problem I'll happily deactivate the plugin and submit a new pull request. The build works (at least on my machine) and as I'm not really a C-guy I didn't write tests however I used the following short shoes script as a little tests whether it works or not:

```
Shoes.app do
  c1 = rgb 255, 120, 0
  c2 = rgb 0, 255, 120
  c3 = rgb 255, 120, 0
  c4 = rgb 20, 20, 20

  stack do
    if c1 == c2
      para "c1 == c2 (undesired behaviour)"
    else
      para "c1 != c2 (desired behaviour)"
    end

    if c1 == c3
      para "c1 == c3 (desired behaviour)"
    else
      para "c1 != c3 (undesired behaviour)"
    end

    if c1 > c4
      para "c1 > c4 (desired behaviour)"
    else
      para "c1 <= c4 (undesired behaviour)"
    end
  end

end
```

Please let me know if I did something totally wrong. :-)

Cheers,
Tobi
