### PR TITLE
Refactor build code to use rake file tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,6 +100,7 @@ when /darwin/
   osx_bootstrap_env
   require File.expand_path('make/darwin/env')
   require_relative "make/darwin/homebrew"
+  import "tasks/req.rake"
 
   task :stub do
     ENV['MACOSX_DEPLOYMENT_TARGET'] = '10.4'
@@ -275,42 +276,6 @@ namespace :osx do
     end
 
     task :pre_build => :check_ruby_arch
-
-    def copy_ext_osx xdir, libdir
-      Dir.chdir(xdir) do
-        `ruby extconf.rb; make >/dev/null 2>&1`
-      end
-      copy_files "#{xdir}/*.bundle", libdir
-    end
-
-    task :common_build do
-      mkdir_p "dist/ruby"
-      cp_r  "#{EXT_RUBY_LIBRUBY}", "dist/ruby/lib"
-      if RUBY_LIB_BASE != 'lib'
-        Dir.chdir(File.join(Dir.pwd,"dist/ruby")) { ln_s "lib", RUBY_LIB_BASE }
-      end
-      unless ENV['STANDARD']
-        %w[soap wsdl xsd].each do |libn|
-          rm_rf "dist/ruby/lib/#{libn}"
-        end
-      end
-      %w[req/ftsearch/lib/* req/rake/lib/*].each do |rdir|
-        FileList[rdir].each { |rlib| cp_r rlib, "dist/ruby/lib" }
-      end
-      %w[req/binject/ext/binject_c req/ftsearch/ext/ftsearchrt req/chipmunk/ext/chipmunk].
-        each { |xdir| copy_ext_osx xdir, "dist/ruby/lib/#{SHOES_RUBY_ARCH}" }
-
-      gdir = "dist/ruby/gems/#{RUBY_V}"
-      {'hpricot' => 'lib', 'json' => 'lib/json/ext', 'sqlite3' => 'lib'}.each do |gemn, xdir|
-        spec = eval(File.read("req/#{gemn}/gemspec"))
-        mkdir_p "#{gdir}/specifications"
-        mkdir_p "#{gdir}/gems/#{spec.full_name}/lib"
-        FileList["req/#{gemn}/lib/*"].each { |rlib| cp_r rlib, "#{gdir}/gems/#{spec.full_name}/lib" }
-        mkdir_p "#{gdir}/gems/#{spec.full_name}/#{xdir}"
-        FileList["req/#{gemn}/ext/*"].each { |elib| copy_ext_osx elib, "#{gdir}/gems/#{spec.full_name}/#{xdir}" }
-        cp "req/#{gemn}/gemspec", "#{gdir}/specifications/#{spec.full_name}.gemspec"
-      end
-    end
 
     def dylibs_to_change lib
       `otool -L #{lib}`.split("\n").inject([]) do |dylibs, line|

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,6 @@ require 'find'
 include FileUtils
 require 'yaml'
 
-YAML::ENGINE.yamler = 'syck' # Use Syck for backward compatibility
-
 # Use Syck for backward compatibility
 YAML::ENGINE.yamler = 'syck'
 

--- a/make/darwin/env.rb
+++ b/make/darwin/env.rb
@@ -3,13 +3,9 @@ EXT_RUBY_BIN = File.exists?("deps/ruby/bin") ? "deps/ruby/bin" : RbConfig::CONFI
 EXT_RUBY_LIB = File.exists?("deps/ruby/lib") ? "deps/ruby/lib" : RbConfig::CONFIG['libdir']
 EXT_RUBY_LIBRUBY = File.exists?("deps/ruby/lib/ruby/#{RUBY_V}") ? "deps/ruby/lib/ruby/#{RUBY_V}" : RbConfig::CONFIG['rubylibdir']
 
-# use the platform Ruby claims
-require 'rbconfig'
+CC = ENV['CC'] || "gcc"
+SRC = FileList["shoes/*.c", "shoes/native/cocoa.m", "shoes/http/nsurl.m"]
 
-CC = ENV['CC'] ? ENV['CC'] : "gcc"
-file_list = ["shoes/*.c"] + %w{shoes/native/cocoa.m shoes/http/nsurl.m}
-
-SRC = FileList[*file_list]
 OBJ = SRC.map do |x|
   x.gsub(/\.\w+$/, '.o')
 end
@@ -34,8 +30,8 @@ LINUX_CFLAGS = %[-Wall -I#{ENV['SHOES_DEPS_PATH'] || "/usr"}/include #{CAIRO_CFL
 if RbConfig::CONFIG['rubyhdrdir']
   LINUX_CFLAGS << " -I#{RbConfig::CONFIG['rubyhdrdir']} -I#{RbConfig::CONFIG['rubyhdrdir']}/#{SHOES_RUBY_ARCH}"
 end
-  
-LINUX_LIB_NAMES = %W[#{RUBY_SO} cairo pangocairo-1.0 gif]
+
+LINUX_LIB_NAMES = %W[#{RUBY_SO} pangocairo-1.0 gif pixman-1 jpeg.8]
 
 FLAGS.each do |flag|
   LINUX_CFLAGS << " -D#{flag}" if ENV[flag]
@@ -51,7 +47,6 @@ LINUX_CFLAGS << " -DRUBY_1_9"
 DLEXT = "dylib"
 LINUX_CFLAGS << " -DSHOES_QUARTZ -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -fpascal-strings #{RbConfig::CONFIG["CFLAGS"]} -x objective-c -fobjc-exceptions"
 LINUX_LDFLAGS = "-framework Cocoa -framework Carbon -dynamiclib -Wl,-single_module INSTALL_NAME"
-LINUX_LIB_NAMES << 'pixman-1' << 'jpeg.8'
 
 OSX_SDK = '/Developer/SDKs/MacOSX10.6.sdk'
 ENV['MACOSX_DEPLOYMENT_TARGET'] = '10.6'

--- a/tasks/req.rake
+++ b/tasks/req.rake
@@ -8,11 +8,10 @@
 def create_copy_file_tasks(source_files, source_root, dest_root, invoking_task)
   source_files.each do |source|
     target = source.pathmap("%{#{source_root},#{dest_root}}p")
-    file target => source do |t|
+    directory File.dirname(target)
+    file target => [File.dirname(target), source] do |t|
       cp source, target
     end
-    directory File.dirname(target)
-    file target => File.dirname(target)
     task invoking_task => target
   end
 end
@@ -40,13 +39,13 @@ end
 # Special case (specify here): bundle name is different from paernt dir name
 #   Example: /req/binject/ext/binject_c/binject.bundle
 SPECIAL_BUNDLE_NAMES = {'binject_c' => 'binject', 'sqlite3' => 'sqlite3_native'}
-DIST_RUBY_LIB = "dist/ruby/lib"
-BUNDLE_DIR   = "#{DIST_RUBY_LIB}/#{SHOES_RUBY_ARCH}"
-GEM_DIR      = "dist/ruby/gems/#{RUBY_V}"
-BUNDLED_LIBS = %w[binject ftsearch chipmunk]
-GEMS         = %w[hpricot json sqlite3 redcarpet2]
-SPECIAL_EXT_DIRS = {'json' => 'lib/json/ext'}
-directory "#{GEM_DIR}/specifications"
+DIST_RUBY_LIB        = "dist/ruby/lib"
+BUNDLE_DIR           = "#{DIST_RUBY_LIB}/#{SHOES_RUBY_ARCH}"
+GEM_DIR              = "dist/ruby/gems/#{RUBY_V}"
+GEMSPEC_DIR          = "#{GEM_DIR}/specifications"
+BUNDLED_LIBS         = %w[binject ftsearch chipmunk]
+GEMS                 = %w[hpricot json sqlite3 redcarpet2]
+SPECIAL_EXT_DIRS     = {'json' => 'lib/json/ext'}
 
 # Copy Ruby source to dist
 create_copy_file_tasks(FileList["#{EXT_RUBY_LIBRUBY}/**/*.{rb,so,bundle}"], EXT_RUBY_LIBRUBY, DIST_RUBY_LIB, :req)
@@ -55,15 +54,23 @@ create_copy_file_tasks(FileList["#{EXT_RUBY_LIBRUBY}/**/*.{rb,so,bundle}"], EXT_
 # dist/
 GEMS.each do |gem_name|
   gem_root_dir = "req/#{gem_name}"
-  spec = eval(File.read(FileList["#{gem_root_dir}/{*.gemspec,gemspec}"].first))
-  dest_dir = "#{GEM_DIR}/gems/#{spec.full_name}"
+  gemspec = FileList["#{gem_root_dir}/{*.gemspec,gemspec}"].first
+  gem_full_name = eval(File.read(gemspec)).full_name
+  gemspec_target = "#{GEMSPEC_DIR}/#{gem_full_name}.gemspec"
+  dest_dir = "#{GEM_DIR}/gems/#{gem_full_name}"
   ext_dir = "#{dest_dir}/#{SPECIAL_EXT_DIRS[gem_name] || 'lib'}"
 
   FileList["#{gem_root_dir}/ext/*"].each do |ext|
     create_compile_ext_tasks(ext, ext_dir, :req)
   end
   create_copy_file_tasks(FileList["#{gem_root_dir}/lib/**/*.rb"], gem_root_dir, dest_dir, :req)
+  # Treat gemspecs differently, because they get renamed.
+  file gemspec_target => [GEMSPEC_DIR, gemspec] do
+    cp gemspec, gemspec_target
+  end
+  task :req => gemspec_target
 end
+directory GEMSPEC_DIR
 
 # Compile bundled library extensions. Copy library's ruby source and compiled
 # extensions to dist/

--- a/tasks/req.rake
+++ b/tasks/req.rake
@@ -1,0 +1,91 @@
+# Create all of the file tasks necessary to copy a tree of files
+#
+# source_files  - a collection of the source files to copy
+# source_root   - the common root dir of the source files
+# dest_root     - the common root dir to which files should be copied
+# invoking_task - the rake task name that will invoke tasks created here. The
+#                 invoking_task depends on these files existing in dest_root.
+def create_copy_file_tasks(source_files, source_root, dest_root, invoking_task)
+  source_files.each do |source|
+    target = source.pathmap("%{#{source_root},#{dest_root}}p")
+    file target => source do |t|
+      cp source, target
+    end
+    directory File.dirname(target)
+    file target => File.dirname(target)
+    task invoking_task => target
+  end
+end
+
+# Create all of the tasks necessary to compile a c-extension for a library, and
+# copy the compiled extension
+#
+# source_root   - the extension's source root (must contain 'extconf.rb')
+# dest_root     - the directory to which the compiled extension should be copied
+# invoking_task - the rake task name that will invoke tasks created here. The
+#                 invoking_task depends on these files existing in dest_root.
+def create_compile_ext_tasks(source_root, dest_root, invoking_task)
+  compiled_ext = "#{source_root}/#{SPECIAL_BUNDLE_NAMES[File.basename(source_root)] || File.basename(source_root)}.bundle"
+  create_copy_file_tasks(FileList[compiled_ext], source_root, dest_root, invoking_task)
+  file compiled_ext => FileList["#{source_root}/*.c"] do
+    cd source_root do
+      `ruby extconf.rb; make >/dev/null 2>&1`
+    end
+  end
+end
+
+# Normal case (default): bundle name matches parent dir name
+#   Example: /req/chipmunk/ext/chipmunk/chipmunk.bundle
+#
+# Special case (specify here): bundle name is different from paernt dir name
+#   Example: /req/binject/ext/binject_c/binject.bundle
+SPECIAL_BUNDLE_NAMES = {'binject_c' => 'binject', 'sqlite3' => 'sqlite3_native'}
+DIST_RUBY_LIB = "dist/ruby/lib"
+BUNDLE_DIR   = "#{DIST_RUBY_LIB}/#{SHOES_RUBY_ARCH}"
+GEM_DIR      = "dist/ruby/gems/#{RUBY_V}"
+BUNDLED_LIBS = %w[binject ftsearch chipmunk]
+GEMS         = %w[hpricot json sqlite3 redcarpet2]
+SPECIAL_EXT_DIRS = {'json' => 'lib/json/ext'}
+directory "#{GEM_DIR}/specifications"
+
+# Copy Ruby source to dist
+create_copy_file_tasks(FileList["#{EXT_RUBY_LIBRUBY}/**/*.{rb,so,bundle}"], EXT_RUBY_LIBRUBY, DIST_RUBY_LIB, :req)
+
+# Compile gem extensions. Copy gem's ruby source and compiled extensions to
+# dist/
+GEMS.each do |gem_name|
+  gem_root_dir = "req/#{gem_name}"
+  spec = eval(File.read(FileList["#{gem_root_dir}/{*.gemspec,gemspec}"].first))
+  dest_dir = "#{GEM_DIR}/gems/#{spec.full_name}"
+  ext_dir = "#{dest_dir}/#{SPECIAL_EXT_DIRS[gem_name] || 'lib'}"
+
+  FileList["#{gem_root_dir}/ext/*"].each do |ext|
+    create_compile_ext_tasks(ext, ext_dir, :req)
+  end
+  create_copy_file_tasks(FileList["#{gem_root_dir}/lib/**/*.rb"], gem_root_dir, dest_dir, :req)
+end
+
+# Compile bundled library extensions. Copy library's ruby source and compiled
+# extensions to dist/
+#
+# (These libs are not packaged as gems. If they were, they wouldn't require
+# special treatment.)
+BUNDLED_LIBS.each do |lib|
+  FileList["req/#{lib}/ext/*"].each do |ext|
+    create_compile_ext_tasks(ext, BUNDLE_DIR, :req)
+  end
+  create_copy_file_tasks(FileList["req/#{lib}/lib/**/*.rb"], "req/#{lib}/lib", DIST_RUBY_LIB, :req)
+end
+
+# TODO: Is the code in this task still necessary?
+task :common_build => :req do
+  if RUBY_LIB_BASE != 'lib'
+    Dir.chdir(File.join(Dir.pwd,"dist/ruby")) { ln_s "lib", RUBY_LIB_BASE }
+  end
+  unless ENV['STANDARD']
+    %w[soap wsdl xsd].each do |libn|
+      rm_rf "dist/ruby/lib/#{libn}"
+    end
+  end
+end
+


### PR DESCRIPTION
A couple of times, I've seen folks drop by #shoes and offer to help. The Rakefile is always _really_ intimidating to newcomers. And the build is _SLOW_.

This is a first effort at rewriting some of the build code to use "real" rake file tasks instead of procedural code. **Please provide feedback:** Is this a good direction to go in?

At this point, I've only rewritten the code that
- copies ruby to dist/
- compiles and copies gems and bundled libraries (binject, chipmunk, etc) to dist/

Also, this is only in the OSX build process at the moment, but it should be simple to extend.
## Benefits
- extensions are only compiled when needed. In cheap, informal tests, this seems to save a couple of seconds at least. Would save more time if we compiled Shoes proper in this manner.
- the code is documented :)
## Drawbacks
- the code is a little more verbose
- because it creates a task for each file, a `rake --trace` is _very_ verbose. I think this would be reduced if, instead of creating a task for each file, we created a task for each directory.
