### PR TITLE
Fixed linux task find_and_copy so that only files are tried to be copied...

### DIFF
--- a/make/linux/tasks.rb
+++ b/make/linux/tasks.rb
@@ -24,7 +24,7 @@ class MakeLinux
           "/usr/lib/i386-linux-gnu/#{thelib}"
         ]
         testpath.each do |tp|
-          if File.exists? tp
+          if File.exists?(tp) && File.file?(tp)
             cp tp, newplace
             return
           end


### PR DESCRIPTION
... and no directories.

Error occurred on Ubuntu 12.04 LTS.
