### PR TITLE
changed the version string to a better format

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -147,7 +147,7 @@ end
 
 task "dist/VERSION.txt" do |t|
   File.open(t.name, 'w') do |f|
-    f << %{shoes #{RELEASE_NAME.downcase} (0.r#{REVISION}) [#{RUBY_PLATFORM} Ruby#{RUBY_VERSION}]}
+		f << %{shoes #{RELEASE_ID} \"#{RELEASE_NAME}\" [#{RUBY_PLATFORM} Ruby-#{RUBY_VERSION}]}
     %w[VIDEO DEBUG].each { |x| f << " +#{x.downcase}" if ENV[x] }
     f << "\n"
   end


### PR DESCRIPTION
It looks like
`shoes 3.1 "Policeman" [i686-linux Ruby-1.9.3]`
now.

Solving issue https://github.com/shoes/shoes/issues/101
